### PR TITLE
nullチェックの追加

### DIFF
--- a/Assets/LucidEditor/Editor/Utils/InspectorPropertyUtil.cs
+++ b/Assets/LucidEditor/Editor/Utils/InspectorPropertyUtil.cs
@@ -59,6 +59,11 @@ namespace AnnulusGames.LucidTools.Editor
         {
             var list = new List<InspectorProperty>();
 
+            if(targetObject == null)
+            {
+                return list;
+            }
+
             foreach (MemberInfo memberInfo in ReflectionUtil.GetAllMembers(targetObject.GetType(), (BindingFlags)(-1), inherit: true))
             {
                 if (memberInfo is FieldInfo fieldInfo)


### PR DESCRIPTION
targetObjectがnullのケース（ScriptableObjectの.csファイルを消した際など）で、
.GetType()が失敗し、コンソールウィンドウにエラーが出てしまうのでnullチェックを追加し、
空のリストを返すようにしました。

また、より望ましい修正方法がある場合、このプルリクエストを閉じていただければと思います。
よろしくお願いします。