### PR TITLE
CustomEditor attribute の isFallbackフラグをtrueにする

### DIFF
--- a/Assets/LucidEditor/Editor/LucidEditor.cs
+++ b/Assets/LucidEditor/Editor/LucidEditor.cs
@@ -91,11 +91,11 @@ namespace AnnulusGames.LucidTools.Editor
     }
 
     [CanEditMultipleObjects]
-    [CustomEditor(typeof(MonoBehaviour), true)]
+    [CustomEditor(typeof(MonoBehaviour), true, isFallback = true)]
     internal class MonoBehaviourEditor : LucidEditor { }
 
     [CanEditMultipleObjects]
-    [CustomEditor(typeof(ScriptableObject), true)]
+    [CustomEditor(typeof(ScriptableObject), true, isFallback = true)]
     internal class ScriptableObjectEditor : LucidEditor { }
 
 }


### PR DESCRIPTION
## 変更内容

CustomEditor attribute の`isFallback`フラグを`true`に変更しました。

## 発生した問題
`ScriptableObject`を継承している`TrackAsset`（TimelineのTrack）の、Timeline内でトラックを選択した際のインスペクターの表示が、当ライブラリを追加した前後で変わってしまうものがありました。（確認しやすいのはCinemachineパッケージに含まれる、`CinemachineTrack`です）

TrackAssetのデフォルトの見た目は以下のスクリプトで定義されていますが、
`com.unity.timeline/Editor/inspectors/TrackAssetInspector.cs`
こちらのCustomEditorでは
```
    [CustomEditor(typeof(TrackAsset), true, isFallback = true)]
    [CanEditMultipleObjects]
    class TrackAssetInspector : Editor
    {
    ...
```
と定義されており、 `isFallback = true` なので `LucidEditor.cs` の `ScriptableObjectEditor` が優先されてしまい、結果的に見た目が変わってしまうようです。

このことによる実質的な副作用は、

- アイコンが変わる（ScriptableObjectデフォルトのアイコンになる）
- インスペクター上でトラック名を変更できなくなる

というものであり、特に後者のトラック名を変更できなくなってしまうことがTimelineを使用するうえで不都合なものになっています。

当PRを取り込んでいただくと、`TrackAssetInspector.cs` が優先されるようになり（ `isFallback` が同値の時は、子クラスで書かれている方を優先するようです）表示が元に戻ることが確認されます。