### PR TITLE
Return bool from EndChangeCheck() in LucidEditorGUI.cs

### DIFF
--- a/Assets/LucidEditor/Editor/LucidEditorGUI.cs
+++ b/Assets/LucidEditor/Editor/LucidEditorGUI.cs
@@ -923,9 +923,9 @@ namespace AnnulusGames.LucidTools.Editor
             EditorGUI.BeginChangeCheck();
         }
 
-        public static void EndChangeCheck()
+        public static bool EndChangeCheck()
         {
-            EditorGUI.EndChangeCheck();
+            return EditorGUI.EndChangeCheck();
         }
 
         public static GUIContent BeginProperty(Rect totalPosition, GUIContent label, SerializedProperty property)


### PR DESCRIPTION
The rationale for this change is to better align with common Unity patterns used in custom editors. Currently, this method acts as a wrapper over Unity's `EditorGUI.EndChangeCheck()`, but doesn't return the result. This is an issue because the typical usage of `EditorGUI.EndChangeCheck()` is in an if-statement to perform some action when changes have been made in the GUI, such as marking objects as dirty, updating related data, etc.

This change makes the `EndChangeCheck()` method in `LucidEditorGUI.cs` more consistent with the behavior of Unity's `EditorGUI.EndChangeCheck()`, and allows it to be used in the same way - providing the caller with crucial information about whether changes have occurred.

Please review the changes and let me know if I missed anything.